### PR TITLE
Basic python3 compatibility

### DIFF
--- a/MunkiReportPackager.py
+++ b/MunkiReportPackager.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for MunkiReportPackager class"""
 
+from __future__ import absolute_import
 import os
 import stat
 import subprocess

--- a/MunkiReportPackager.py
+++ b/MunkiReportPackager.py
@@ -16,11 +16,12 @@
 """See docstring for MunkiReportPackager class"""
 
 from __future__ import absolute_import
+
 import os
 import stat
 import subprocess
-import FoundationPlist
 
+import FoundationPlist
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["MunkiReportPackager"]

--- a/MunkiReportUrlCreator.py
+++ b/MunkiReportUrlCreator.py
@@ -16,6 +16,7 @@
 
 """See docstring for MunkiReportUrlCreator class"""
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["MunkiReportUrlCreator"]

--- a/MunkiReportUrlCreator.py
+++ b/MunkiReportUrlCreator.py
@@ -17,6 +17,7 @@
 """See docstring for MunkiReportUrlCreator class"""
 
 from __future__ import absolute_import
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["MunkiReportUrlCreator"]


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.