### PR TITLE
Update Python path to reflect changes in macOS 12.3+

### DIFF
--- a/MunkiReportPackager.py
+++ b/MunkiReportPackager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2015 Arjen van Bochoven
 #
@@ -29,20 +29,18 @@ __all__ = ["MunkiReportPackager"]
 
 class MunkiReportPackager(Processor):
     """Creates a package."""
+
     description = __doc__
     input_variables = {
         "pathname": {
             "required": True,
             "description": "Path to the install script.",
         },
-        "version": {
-            "required": False,
-            "description": "A preferred version"
-        },
+        "version": {"required": False, "description": "A preferred version"},
         "baseurl": {
             "required": True,
             "description": "URL for a Munkireport packager script.",
-        }
+        },
     }
     output_variables = {
         "pkg_path": {
@@ -59,15 +57,19 @@ class MunkiReportPackager(Processor):
         # Packagedir
         packagedir = os.path.join(self.env["RECIPE_CACHE_DIR"], "downloads")
         # Result plist
-        resultplist = os.path.join(self.env["RECIPE_CACHE_DIR"],
-                                   "result.plist")
+        resultplist = os.path.join(self.env["RECIPE_CACHE_DIR"], "result.plist")
         # BaseURL
         baseurl = self.env.get("baseurl")
         if not baseurl.endswith("/"):
             baseurl = baseurl + "/"
         args = [
-            self.env["pathname"], "-b", baseurl, "-i", packagedir, "-r",
-            resultplist
+            self.env["pathname"],
+            "-b",
+            baseurl,
+            "-i",
+            packagedir,
+            "-r",
+            resultplist,
         ]
 
         preferred_version = self.env.get("version")
@@ -77,19 +79,24 @@ class MunkiReportPackager(Processor):
         # Call script.
         try:
             proc = subprocess.Popen(
-                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
             (out, err_out) = proc.communicate()
         except OSError as err:
             raise ProcessorError(
                 "The downloaded script contains errors, please check \
-%s. (Error code %d: %s)" % (self.env["pathname"], err.errno, err.strerror))
+%s. (Error code %d: %s)"
+                % (self.env["pathname"], err.errno, err.strerror)
+            )
         if proc.returncode != 0:
-            raise ProcessorError("creating package for %s failed: %s" %
-                                 (self.env["pathname"], err_out))
+            raise ProcessorError(
+                "creating package for %s failed: %s" % (self.env["pathname"], err_out)
+            )
 
         if not os.path.isfile(resultplist):
-            raise ProcessorError("no result plist found, run against " \
-            "Munkireport 2.5.3 or higher")
+            raise ProcessorError(
+                "no result plist found, run against " "Munkireport 2.5.3 or higher"
+            )
 
         # Get package path from resultplist
         result = plistlib.readPlist(resultplist)
@@ -97,6 +104,6 @@ class MunkiReportPackager(Processor):
         self.env["pkg_path"] = result["pkg_path"]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     PROCESSOR = MunkiReportPackager()
     PROCESSOR.execute_shell()

--- a/MunkiReportUrlCreator.py
+++ b/MunkiReportUrlCreator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/local/autopkg/python
 #
 # Copyright 2015 Arjen van Bochoven
 #
@@ -22,8 +22,10 @@ from autopkglib import Processor, ProcessorError
 
 __all__ = ["MunkiReportUrlCreator"]
 
+
 class MunkiReportUrlCreator(Processor):
     """Provides URL to the latest update."""
+
     description = __doc__
     input_variables = {
         "baseurl": {
@@ -32,9 +34,8 @@ class MunkiReportUrlCreator(Processor):
         },
         "modules": {
             "required": False,
-            "description":
-                "Array of modules to include in the install.",
-        }
+            "description": "Array of modules to include in the install.",
+        },
     }
     output_variables = {
         "url": {
@@ -51,11 +52,12 @@ class MunkiReportUrlCreator(Processor):
         modules = self.env.get("modules")
         if modules:
             for module in modules:
-                url = url + '/' + module
+                url = url + "/" + module
             # Format description
 
         self.env["url"] = url
         self.output("Found URL %s" % self.env["url"])
+
 
 if __name__ == "__main__":
     PROCESSOR = MunkiReportUrlCreator()


### PR DESCRIPTION
As of macOS Monterey 12.3, the version of Python 2 that shipped with macOS located at `/usr/bin/python` [has been removed](https://developer.apple.com/documentation/macos-release-notes/macos-12_3-release-notes). More context can be found in some posts from Mac admins at the beginning of 2022, aggregated [here](https://scriptingosx.com/2022/03/macos-monterey-12-3-removes-python-2-link-collection/).

Since [version 2.0.2](https://github.com/autopkg/autopkg/releases/tag/v2.0.2), AutoPkg's installer has included its own Python 3 framework, symlinked from `/usr/local/autopkg/python`. Similarly, Munki ships with its own Python 3 framework, symlinked from `/usr/local/munki/munki-python`. This pull request adjusts the shebang and interpreter paths of processors, pre/post install scripts, and other files to replace `/usr/bin/python` with the AutoPkg or Munki Python 3 symlinks as appropriate.

NOTE: Because AutoPkg processors are imported as modules by AutoPkg and not executed directly, processors' shebang has no effect in normal usage. However: (a) some people execute processors directly during testing, and these tests won't work unless the shebang points to a valid Python 3, and (b) having instances of `/usr/bin/python` in the codebase could lead to confusion for people not deeply familiar with processor behavior.