### PR TITLE
Catch deprecated .readPlist in Py3.9+, use .load and open()

### DIFF
--- a/MunkiReportPackager.py
+++ b/MunkiReportPackager.py
@@ -91,8 +91,11 @@ class MunkiReportPackager(Processor):
             raise ProcessorError("no result plist found, run against " \
             "Munkireport 2.5.3 or higher")
 
-        # Get package path from resultplist
-        result = plistlib.readPlist(resultplist)
+        # Get package path from resultplist - catch deprecated .readPlist in Py3.9
+        try:
+            result = plistlib.readPlist(resultplist)
+        except AttributeError:
+            result = plistlib.load(open(resultplist, "rb"))
         self.output("Created package %s" % result["pkg_path"])
         self.env["pkg_path"] = result["pkg_path"]
 


### PR DESCRIPTION
AutoPkg 2.7 uses Python 3.10. `plistlib` in Python 3.9+ no longer supports `.readPlist`. 

This tries `.readPlist` and if it fails uses `.load`, allowing for the processor to still work with AutoPKG 2.4.1 and older.